### PR TITLE
Make site permissions optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,4 @@
-config.json
 node_modules
-npm-debug.log
-src/js/test.js
 .jshintrc
-admin.html
-src/js/admin.js
-.idea
 dist/*
 !dist/browser-polyfill.min.js

--- a/src/about.html
+++ b/src/about.html
@@ -37,14 +37,14 @@
                 <p>There are two views in Pulltabs, a simple view and and advanced view. You can use either or both at the same time. Simply check off which views you'd like chosen in the Options menu. The simple view sends all your tabs to a single destination or performs a single action on each tab. The advanced view is more granular and allows you to choose an action/destination per each tab, including deactivating particular tabs and having Pulltabs ignore them.</p>
 
                 <h4>Credits</h4>
-                <p>Pull Tabs - <a href="http://the42ndestate.com/">The 42nd Estate</a></p>
-                <p>Developed by: <a href="http://adamp.com/">Adam Pieniazek</a></p>
-                <p>Icon: Pull Tab designed by <a href="http://www.thenounproject.com/chamaquitopan">Chamaquito Pan de Dulce</a> from the <a href="http://www.thenounproject.com">Noun Project</a></p>
+                <p><a href="https://adam42.github.io/pull-tabs/">Pull Tabs</a></p>
+                <p>Developed by: <a href="https://adamp.com/">Adam Pieniazek</a></p>
+                <p>Icon: Pull Tab designed by <a href="https://www.thenounproject.com/chamaquitopan">Chamaquito Pan de Dulce</a> from the <a href="http://www.thenounproject.com">Noun Project</a></p>
                 <p>Icon: Bookmark by <a href="https://thenounproject.com/mabusafiah/">Muneer A.Safiah</a> from the Noun Project</p>
                 <p>Icon: Close by <a href="https://thenounproject.com/miwa87/">Michael Wallner</a> from the Noun Project</p>
                 <p>Icon: Download by <a href="https://thenounproject.com/alexfuller/"> Alex Fuller</a> from the Noun Project</p>
                 <p>Icon: Ignore by <a href="https://thenounproject.com/riginos/">Konstantinos Riginos</a> from the Noun Project</p>
-                <p>Icon: Pocket and other icons from <a href="http://simpleicons.org/">Simple Icons</a></p>
+                <p>Icon: Pocket and other icons from <a href="https://simpleicons.org/">Simple Icons</a></p>
             </div>
         </div>
 

--- a/src/about.html
+++ b/src/about.html
@@ -39,7 +39,7 @@
                 <h4>Credits</h4>
                 <p><a href="https://adam42.github.io/pull-tabs/">Pull Tabs</a></p>
                 <p>Developed by: <a href="https://adamp.com/">Adam Pieniazek</a></p>
-                <p>Icon: Pull Tab designed by <a href="https://www.thenounproject.com/chamaquitopan">Chamaquito Pan de Dulce</a> from the <a href="http://www.thenounproject.com">Noun Project</a></p>
+                <p>Icon: Pull Tab designed by <a href="https://www.thenounproject.com/chamaquitopan">Chamaquito Pan de Dulce</a> from the <a href="https://www.thenounproject.com">Noun Project</a></p>
                 <p>Icon: Bookmark by <a href="https://thenounproject.com/mabusafiah/">Muneer A.Safiah</a> from the Noun Project</p>
                 <p>Icon: Close by <a href="https://thenounproject.com/miwa87/">Michael Wallner</a> from the Noun Project</p>
                 <p>Icon: Download by <a href="https://thenounproject.com/alexfuller/"> Alex Fuller</a> from the Noun Project</p>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -16,11 +16,10 @@
         "identity",
         "bookmarks",
         "storage",
-        "http://*/*",
-        "https://*/*",
+
         "https://getpocket.com/v3/*"
     ],
-
+    "optional_permissions": ["http://*/*", "https://*/*"],
     "web_accessible_resources": ["pocket.html"],
 
     "browser_action": {


### PR DESCRIPTION
Permissions to access all sites is only needed for advanced UI's mimeType checking, which is currently disabled anyway. When mimeType checking is enabled, request permissions then. Users who don't have mimeType checking enabled don't need to provide permissions to all sites.